### PR TITLE
vulkan-loader 1.4.313.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
+{% set name = "vulkan-loader" %}
 {% set version = "1.4.313.0" %}
 
 package:
-  name: libvulkan-loader
+  name: {{ name }}
   version: {{ version }}
 
 # For this repo, v**** tags exists, but apparently the stable tags (the one corresponding to versions
@@ -14,10 +15,13 @@ source:
     - disable_macos_framework.patch
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports_from:
     # only the headers are used by the feedstock
     - libxcb  # [linux]
+  run_exports:
+    - {{ pin_subpackage(name|lower, max_pin='x.x') }}
+
 
 requirements:
   build:


### PR DESCRIPTION
vulkan-loader 1.4.313.0 

**Destination channel:** Defaults

### Links

- [PKG-14702]
- dev_url:        https://github.com/KhronosGroup/Vulkan-Loader/tree/vulkan-sdk-1.4.313.0
- conda_forge:    https://github.com/conda-forge/vulkan-loader-feedstock
- pypi:           https://pypi.org/project/vulkan-loader/1.4.313.0
- pypi inspector: https://inspector.pypi.io/project/vulkan-loader/1.4.313.0

### Explanation of changes:

- new build number
- generate `run-exports`
  - this is to then have _aggregate-duct-tape_ generate a `vulcan-loader` in `cbc.yaml` for others to use

Other users used to use `libvulkan` which was removed from `cbc.yaml` in April 2026:
```
$grep -l libvulkan */recipe/*.yaml
mesalib-feedstock/recipe/meta.yaml
pyqt-feedstock/recipe/meta.yaml
pyside6-feedstock/recipe/meta.yaml
qtbase-feedstock/recipe/meta.yaml
qtdeclarative-feedstock/recipe/meta.yaml
qttools-feedstock/recipe/meta.yaml
qtwayland-feedstock/recipe/meta.yaml
qtwebengine-feedstock/recipe/meta.yaml
vulkan-headers-feedstock/recipe/meta.yaml
vulkan-loader-feedstock/recipe/meta.yaml
```

and will need updating to use `vulkan-loader` moving forwards.


[PKG-14702]: https://anaconda.atlassian.net/browse/PKG-14702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ